### PR TITLE
Update runner from `node16` to `node20`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,4 +12,4 @@ jobs:
   test:
     uses: stylelint/.github/.github/workflows/test.yml@main
     with:
-      node-version: '["16"]'
+      node-version: '["20"]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   lint:
     uses: stylelint/.github/.github/workflows/lint.yml@main
+    with:
+      node-version: '20'
 
   test:
     uses: stylelint/.github/.github/workflows/test.yml@main

--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@stylelint/prettier-config": "^3.0.0",
         "@stylelint/remark-preset": "^4.0.0",
-        "@tsconfig/node16": "^16.1.1",
+        "@tsconfig/node20": "^20.1.2",
         "@tsconfig/strictest": "^2.0.2",
         "@types/mdast": "^4.0.0",
         "@vercel/ncc": "^0.36.1",
@@ -30,7 +30,7 @@
         "vitest": "^0.34.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@actions/core": {
@@ -848,10 +848,10 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@tsconfig/node16": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.1.tgz",
-      "integrity": "sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==",
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.2.tgz",
+      "integrity": "sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ==",
       "dev": true
     },
     "node_modules/@tsconfig/strictest": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@stylelint/prettier-config": "^3.0.0",
     "@stylelint/remark-preset": "^4.0.0",
-    "@tsconfig/node16": "^16.1.1",
+    "@tsconfig/node20": "^20.1.2",
     "@tsconfig/strictest": "^2.0.2",
     "@types/mdast": "^4.0.0",
     "@vercel/ncc": "^0.36.1",
@@ -50,6 +50,6 @@
     "vitest": "^0.34.3"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node16/tsconfig"],
+	"extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node20/tsconfig"],
 	"compilerOptions": {
 		"noEmit": true
 	},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

`node20` runner has been added in <https://github.com/actions/runner/releases/tag/v2.308.0>.
