### PR TITLE
Check that markdown header starts with version instead of is the version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -50332,7 +50332,12 @@ function extractChangeItems({ version }) {
 
 		visit(tree, 'heading', (node, index, parent) => {
 			const [text] = node.children;
-			if (text?.type === 'text' && text.value === version && parent && index !== undefined) {
+			if (
+				text?.type === 'text' &&
+				text.value.startsWith(version) &&
+				parent &&
+				index !== undefined
+			) {
 				const nextSibling = parent.children[index + 1];
 				if (nextSibling?.type === 'list') {
 					list = nextSibling;

--- a/src/__tests__/changelogToGithubRelease.test.js
+++ b/src/__tests__/changelogToGithubRelease.test.js
@@ -6,6 +6,10 @@ import { changelogToGithubRelease } from '../changelogToGithubRelease.js';
 const changelog = `
 # Changelog
 
+## 1.1.0 - 2024-12-31
+- ddd [#123](https://github.com/foo/bar/pull/123) ([@user](https://github.com/user)).
+- eee.
+
 ## 1.0.0
 - aaa [#123](https://github.com/foo/bar/pull/123) ([@user](https://github.com/user)).
 - bbb.
@@ -13,6 +17,16 @@ const changelog = `
 ## 0.1.0
 - ccc.
 `;
+
+test('rewrite change items for version with date in heading', async () => {
+	const result = await changelogToGithubRelease(changelog, '1.1.0');
+	assert.equal(
+		result,
+		`* ddd #123 (@user).
+* eee.
+`,
+	);
+});
 
 test('rewrite change items matching specified version', async () => {
 	const result = await changelogToGithubRelease(changelog, '1.0.0');

--- a/src/changelogToGithubRelease.js
+++ b/src/changelogToGithubRelease.js
@@ -12,7 +12,12 @@ function extractChangeItems({ version }) {
 
 		visit(tree, 'heading', (node, index, parent) => {
 			const [text] = node.children;
-			if (text?.type === 'text' && text.value.startsWith(version) && parent && index !== undefined) {
+			if (
+				text?.type === 'text' &&
+				text.value.startsWith(version) &&
+				parent &&
+				index !== undefined
+			) {
 				const nextSibling = parent.children[index + 1];
 				if (nextSibling?.type === 'list') {
 					list = nextSibling;

--- a/src/changelogToGithubRelease.js
+++ b/src/changelogToGithubRelease.js
@@ -12,7 +12,7 @@ function extractChangeItems({ version }) {
 
 		visit(tree, 'heading', (node, index, parent) => {
 			const [text] = node.children;
-			if (text?.type === 'text' && text.value === version && parent && index !== undefined) {
+			if (text?.type === 'text' && text.value.startsWith(version) && parent && index !== undefined) {
 				const nextSibling = parent.children[index + 1];
 				if (nextSibling?.type === 'list') {
 					list = nextSibling;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

This is in relation to the discussion at https://github.com/stylelint/stylelint/pull/8260 which is in support of adding a date to the Changelog for each release

> Is there anything in the PR that needs further explanation?

Full explanation is at this point in the pull request: https://github.com/stylelint/stylelint/pull/8260#issuecomment-2565909498, but the idea is that if the Markdown header for the release version is not exclusively in the `X.Y.Z` format because it now `X.Y.Z - YYYY-MM-DD`, then the change in this pull request would be needed in order to format the GitHub Release text properly