### PR TITLE
Add notice message to action run page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Added: notice message to action run page.
+
 ## 0.2.3 - 2025-04-08
 
 - Fixed: bump `@octokit/plugin-paginate-rest` to `9.2.2` for security fix ([#65][]) ([@dependabot][]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Head
 
-- Added: notice message to action run page.
+- Added: notice message to action run page ([#70][]) ([@ybiquitous][]).
 
 ## 0.2.3 - 2025-04-08
 
@@ -75,6 +75,7 @@ Initial release.
 [#63]: https://github.com/stylelint/changelog-to-github-release-action/pull/63
 [#65]: https://github.com/stylelint/changelog-to-github-release-action/pull/65
 [#66]: https://github.com/stylelint/changelog-to-github-release-action/pull/66
+[#70]: https://github.com/stylelint/changelog-to-github-release-action/pull/70
 
 <!-- In alphabetical order -->
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -50418,7 +50418,7 @@ async function main() {
 		body,
 		draft,
 	});
-	core.info(`Created release: ${data.html_url}`);
+	core.notice(`Created release: ${data.html_url}`);
 }
 
 if (process.env['NODE_ENV'] !== 'test') {

--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@ async function main() {
 		body,
 		draft,
 	});
-	core.info(`Created release: ${data.html_url}`);
+	core.notice(`Created release: ${data.html_url}`);
 }
 
 if (process.env['NODE_ENV'] !== 'test') {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This change outputs a notice message with a new release link to an action run page.

Ref https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-notice-message

