### PR TITLE
Bump runner Node.js version from `node20` to `node24`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,23 @@ on:
 permissions: read-all
 
 jobs:
+  get-node-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.node-version.outputs.value }}
+    steps:
+      - id: node-version
+        shell: bash
+        run: echo "value=$(npm pkg get engines.node | jq -r)" >> "${GITHUB_OUTPUT}"
+
   lint:
+    needs: get-node-version
     uses: stylelint/.github/.github/workflows/lint.yml@main
     with:
-      node-version: '20'
+      node-version: ${{ needs.get-node-version.outputs.version }}
 
   test:
+    needs: get-node-version
     uses: stylelint/.github/.github/workflows/test.yml@main
     with:
-      node-version: '["20"]'
+      node-version: ${{ needs.get-node-version.outputs.version}}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx --no lint-staged
+lint-staged

--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@stylelint/prettier-config": "^3.0.0",
         "@stylelint/remark-preset": "^5.1.1",
-        "@tsconfig/node20": "^20.1.6",
+        "@tsconfig/node24": "^24.0.1",
         "@tsconfig/strictest": "^2.0.5",
         "@types/mdast": "^4.0.4",
         "@vercel/ncc": "^0.38.3",
@@ -29,7 +29,7 @@
         "typescript": "^5.9.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": "24"
       }
     },
     "node_modules/@actions/core": {
@@ -558,11 +558,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.6",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.6.tgz",
-      "integrity": "sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ==",
-      "dev": true
+    "node_modules/@tsconfig/node24": {
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.1.tgz",
+      "integrity": "sha512-3+IXshza3bIrT0tbHBr9CixQDVf4iBf0HTR0hCYowhpLqkzJjswu3UY8aZWjRXZep31kYB+o2SQeD8KwIoUHYw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/strictest": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@stylelint/prettier-config": "^3.0.0",
     "@stylelint/remark-preset": "^5.1.1",
-    "@tsconfig/node20": "^20.1.6",
+    "@tsconfig/node24": "^24.0.1",
     "@tsconfig/strictest": "^2.0.5",
     "@types/mdast": "^4.0.4",
     "@vercel/ncc": "^0.38.3",
@@ -50,6 +50,6 @@
     "typescript": "^5.9.2"
   },
   "engines": {
-    "node": ">=20"
+    "node": "24"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node20/tsconfig"],
+	"extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node24/tsconfig"],
 	"compilerOptions": {
 		"noEmit": true
 	},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Node.js v24 is the latest version that is supported by GitHub Actions.
