### PR TITLE
Improve releasing process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/.github/        @stylelint/owners
+package.json     @stylelint/owners

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,51 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      new-version:
+        description: 'New version to release'
+        required: true
+        type: choice
+        options: [major, minor, patch]
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Bump version
+        id: bump-version
+        shell: bash
+        env:
+          NEW_VERSION: ${{ github.event.inputs.new-version }}
+        run: |
+          npm version "${NEW_VERSION}" --no-git-tag-version
+          echo "value=$(npm pkg get 'version' | jq -r)" >> "${GITHUB_OUTPUT}"
+
+      - name: Get additional info
+        id: get-info
+        shell: bash
+        run: |
+          echo "latest-tag=$(gh release view --json tagName --jq .tagName)" >> "${GITHUB_OUTPUT}"
+
+      - name: Create Release PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: release-${{ steps.bump-version.outputs.value }}
+          assignees: ${{ github.actor }}
+          title: 'Release ${{ steps.bump-version.outputs.value }}'
+          commit-message: 'Release ${{ steps.bump-version.outputs.value }}'
+          body: |
+            This PR prepares the release of version ${{ steps.bump-version.outputs.value }}. Follow the steps below:
+            1. Review the changes: https://github.com/${{ github.repository }}/compare/${{ steps.get-info.outputs.latest-tag }}...release-${{ steps.bump-version.outputs.value }}
+            2. Update the [changelog](https://github.com/${{ github.repository }}/edit/release-${{ steps.bump-version.outputs.value }}/CHANGELOG.md).
+            3. Merge this PR.
+
+            Then, the release workflow will automatically start. Watch [Actions](https://github.com/${{ github.repository }}/actions/).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  push:
-    tags: ['**']
+  pull_request:
+    branches: [main]
+    types: [closed]
 
 concurrency:
   group: ${{ github.workflow }}
@@ -10,6 +11,7 @@ concurrency:
 
 jobs:
   release:
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release-') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -17,5 +19,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Get version
+        id: get-version
+        shell: bash
+        run: echo "value=$(npm pkg get 'version' | jq -r)" >> "${GITHUB_OUTPUT}"
+
       - name: Create release
+        if: ${{ github.event.pull_request.head.ref == format('release-{0}', steps.get-version.outputs.value) }}
         uses: ./
+        with:
+          tag: ${{ steps.get-version.outputs.value }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,8 +9,6 @@ Use the latest version of Node.js and npm.
 
 ## Release
 
-1. Update [`CHANGELOG.md`](CHANGELOG.md) to set the next version and commit the change with a message like `Prepare x.y.z`.
-2. Run `npm version <next_version>`.
-3. Run `git push --follow-tags`.
+Create a release PR from [this GitHub Actions workflow](https://github.com/stylelint/changelog-to-github-release-action/blob/main/.github/workflows/create-release-pr.yml) and merge it.
 
-Then, the [release workflow](.github/workflows/release.yml) will automatically run and a new release will be created.
+After the PR merge, the release will be performed automatically. Check out a new release in [Releases](https://github.com/stylelint/changelog-to-github-release-action/releases).


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This automates the release process through creating a pull request for releases via GitHub Actions.

Here's a new workflow:
1. Create a release PR via a new workflow `create-release-pr.yml`.
2. Merge the PR to `main`.
3. The existing `release.yml` workflow automatically starts, creates a new tag and a GitHub Release.

In short, we will not need more local steps to release.

To avoid accidental releases, this also adds a `CODEOWNERS` file.
It requires approval from the code owners to merge release PRs.
