### PR TITLE
Fix Release workflow failure due to local actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,15 @@ jobs:
 
       - name: Create release
         if: ${{ github.event.pull_request.head.ref == format('release-{0}', steps.get-version.outputs.value) }}
-        uses: ./
+        # NOTE: We cannot use local actions because of the organization-level settings and the follwowing error:
+        #
+        # > The action ./ is not allowed in stylelint/changelog-to-github-release-action because all actions must be from a repository
+        # > owned by stylelint, created by GitHub, or verified in the GitHub Marketplace.
+        # > All actions must also be pinned to a full-length commit SHA.
+        #
+        # See https://github.com/stylelint/changelog-to-github-release-action/actions/runs/17795814148
+        #
+        # uses: ./
+        uses: stylelint/changelog-to-github-release-action@27c30aa2d1b7e31e7845c5fac28f998bd83dd1da # main
         with:
           tag: ${{ steps.get-version.outputs.value }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,6 +9,6 @@ Use the latest version of Node.js and npm.
 
 ## Release
 
-Create a release PR from [this GitHub Actions workflow](https://github.com/stylelint/changelog-to-github-release-action/blob/main/.github/workflows/create-release-pr.yml) and merge it.
+Create a release PR from [this GitHub Actions workflow](https://github.com/stylelint/changelog-to-github-release-action/actions/workflows/create-release-pr.yml) and merge it.
 
 After the PR merge, the release will be performed automatically. Check out a new release in [Releases](https://github.com/stylelint/changelog-to-github-release-action/releases).


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to PR #84

> Is there anything in the PR that needs further explanation?

Our current organization policy requires pinned actions with a full-length commit SHA. This works around the restriction.

See https://github.com/stylelint/changelog-to-github-release-action/actions/runs/17795814148
