### PR TITLE
Fix release workflow due to missing Git tag

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Get additional info
         id: get-info
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "latest-tag=$(gh release view --json tagName --jq .tagName)" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Get version
-        id: get-version
+      - name: Create tag
+        id: create-tag
         shell: bash
-        run: echo "value=$(npm pkg get 'version' | jq -r)" >> "${GITHUB_OUTPUT}"
+        env:
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          NEW_VERSION=$(npm pkg get 'version' | jq -r)
+          if [[ "${PR_BRANCH}" == "release-${NEW_VERSION}" ]]; then
+            git config user.name "${GITHUB_ACTOR}"
+            git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+            git tag "${NEW_VERSION}"
+            git push origin "${NEW_VERSION}"
+            echo "tag=${NEW_VERSION}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "The branch name does not match the version in package.json. Skipped."
+          fi
 
       - name: Create release
-        if: ${{ github.event.pull_request.head.ref == format('release-{0}', steps.get-version.outputs.value) }}
+        if: ${{ steps.create-tag.outputs.tag }}
         # NOTE: We cannot use local actions because of the organization-level settings and the follwowing error:
         #
         # > The action ./ is not allowed in stylelint/changelog-to-github-release-action because all actions must be from a repository
@@ -38,4 +50,4 @@ jobs:
         # uses: ./
         uses: stylelint/changelog-to-github-release-action@27c30aa2d1b7e31e7845c5fac28f998bd83dd1da # main
         with:
-          tag: ${{ steps.get-version.outputs.value }}
+          tag: ${{ steps.create-tag.outputs.tag }}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to PR #84

> Is there anything in the PR that needs further explanation?

We should have created a Git tag before calling `changelog-to-github-release-action`
because this action does not support tag auto-creation.

That's why this change resolves the following error:

```
Error: Not found version: 0.4.0
```

https://github.com/stylelint/changelog-to-github-release-action/actions/runs/17796946474/job/50586734189
