### PR TITLE
Add `name` input to specify release names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Added: `name` input to specify release names ([#91][]) ([@ybiquitous][]).
+
 ## 0.4.0 - 2025-09-17
 
 - Changed: bump runner Node.js version from `node20` to `node24` ([#83][]) ([@ybiquitous][]).
@@ -88,6 +92,7 @@ Initial release.
 [#74]: https://github.com/stylelint/changelog-to-github-release-action/pull/74
 [#76]: https://github.com/stylelint/changelog-to-github-release-action/pull/76
 [#83]: https://github.com/stylelint/changelog-to-github-release-action/pull/83
+[#91]: https://github.com/stylelint/changelog-to-github-release-action/pull/91
 
 <!-- In alphabetical order -->
 

--- a/action.yml
+++ b/action.yml
@@ -3,23 +3,27 @@ description: 'GitHub Action to convert CHANGELOG to GitHub Release'
 author: 'Stylelint'
 inputs:
   tag:
-    description: 'Tag name'
+    description: 'Tag name.'
+    required: false
+    default: '${{ github.ref_name }}'
+  name:
+    description: 'Release name. Default is the tag name.'
     required: false
     default: '${{ github.ref_name }}'
   changelog:
-    description: 'Changelog file path'
+    description: 'Changelog file path.'
     required: false
     default: 'CHANGELOG.md'
   token:
-    description: 'GitHub token'
+    description: 'GitHub token.'
     required: false
     default: '${{ github.token }}'
   repo:
-    description: 'Repository'
+    description: 'Repository.'
     required: false
     default: '${{ github.repository }}'
   draft:
-    description: 'Whether create a draft release'
+    description: 'Whether create a draft release.'
     required: false
     default: 'false'
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -50457,6 +50457,7 @@ async function changelogToGithubRelease(changelog, version) {
 
 async function main() {
 	const tag = core.getInput('tag');
+	const name = core.getInput('name');
 	const changelogPath = core.getInput('changelog');
 	const token = core.getInput('token');
 	const draft = core.getInput('draft') === 'true';
@@ -50475,6 +50476,7 @@ async function main() {
 		owner,
 		repo,
 		tag_name: tag,
+		name,
 		body,
 		draft,
 	});

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import { changelogToGithubRelease } from './changelogToGithubRelease.js';
 
 async function main() {
 	const tag = core.getInput('tag');
+	const name = core.getInput('name');
 	const changelogPath = core.getInput('changelog');
 	const token = core.getInput('token');
 	const draft = core.getInput('draft') === 'true';
@@ -25,6 +26,7 @@ async function main() {
 		owner,
 		repo,
 		tag_name: tag,
+		name,
 		body,
 		draft,
 	});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

For the consistency across all the repositories in the organization, release names are usually the same as their tag names.
E.g. https://github.com/stylelint/stylelint/releases/tag/16.24.0

Ref the [REST API doc](https://docs.github.com/en/rest/releases/releases?versionId=free-pro-team%40latest&productId=subscriptions-and-notifications&restPage=concepts%2Cabout-notifications&apiVersion=2022-11-28#create-a-release--parameters) for creating a release.