### PR TITLE
Fix `name` input's default value when `tag` input is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Fixed: `name` input's default value when `tag` input is set ([#93][]) ([@ybiquitous][]).
+
 ## 0.5.0 - 2025-09-17
 
 - Added: `name` input to specify release names ([#91][]) ([@ybiquitous][]).
@@ -93,6 +97,7 @@ Initial release.
 [#76]: https://github.com/stylelint/changelog-to-github-release-action/pull/76
 [#83]: https://github.com/stylelint/changelog-to-github-release-action/pull/83
 [#91]: https://github.com/stylelint/changelog-to-github-release-action/pull/91
+[#93]: https://github.com/stylelint/changelog-to-github-release-action/pull/93
 
 <!-- In alphabetical order -->
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,6 @@ inputs:
   name:
     description: 'Release name. Default is the tag name.'
     required: false
-    default: '${{ github.ref_name }}'
   changelog:
     description: 'Changelog file path.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -50457,7 +50457,7 @@ async function changelogToGithubRelease(changelog, version) {
 
 async function main() {
 	const tag = core.getInput('tag');
-	const name = core.getInput('name');
+	const name = core.getInput('name') || tag;
 	const changelogPath = core.getInput('changelog');
 	const token = core.getInput('token');
 	const draft = core.getInput('draft') === 'true';

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { changelogToGithubRelease } from './changelogToGithubRelease.js';
 
 async function main() {
 	const tag = core.getInput('tag');
-	const name = core.getInput('name');
+	const name = core.getInput('name') || tag;
 	const changelogPath = core.getInput('changelog');
 	const token = core.getInput('token');
 	const draft = core.getInput('draft') === 'true';


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to PR #91

> Is there anything in the PR that needs further explanation?

`${{ github.ref_name }}` is incorrect for the `name` input's default value
when the `tag` input is set to a specific value.

For example:

```yaml
with:
  tag: 0.4.0
  # when `name` is omitted, it becomes `main` from `${{ github.ref_name }}`.
```
