### PR TITLE
Fix error messages to help troubleshooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed: error messages to help troubleshooting ([#98][]) ([@ybiquitous][]).
+
 ## 0.5.1 - 2025-09-17
 
 - Fixed: `name` input's default value when `tag` input is set ([#93][]) ([@ybiquitous][]).
@@ -98,6 +102,7 @@ Initial release.
 [#83]: https://github.com/stylelint/changelog-to-github-release-action/pull/83
 [#91]: https://github.com/stylelint/changelog-to-github-release-action/pull/91
 [#93]: https://github.com/stylelint/changelog-to-github-release-action/pull/93
+[#98]: https://github.com/stylelint/changelog-to-github-release-action/pull/98
 
 <!-- In alphabetical order -->
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@
 
 ## Usage
 
-Create `.github/workflows/release.yml` with the following content:
+First, create a `CHANGELOG.md` file with the following format, such as:
+
+```markdown
+# Changelog
+
+<!-- Format: "{version} - {iso-date}" -->
+
+## 1.0.0 - 2025-01-01
+
+<!-- Notable changes list -->
+
+- Added: something.
+- Fixed: something.
+```
+
+Next, create `.github/workflows/release.yml` with the following content:
 
 ```yaml
 name: Release
@@ -13,21 +28,18 @@ on:
   push:
     tags: ["**"]
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
-
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    concurrency: ${{ github.workflow }}-${{ github.ref_name }}
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Create release
-        uses: stylelint/changelog-to-github-release-action@0.2.3
+        uses: stylelint/changelog-to-github-release-action@8526eab6046b8f5b2f883844d953b5eb6f80e674 # 0.5.1
 ```
 
 ## Inputs
@@ -36,8 +48,9 @@ You can tune this action by the input parameters, for example:
 
 ```yaml
 - name: Create release
-  uses: stylelint/changelog-to-github-release-action@0.2.3
+  uses: stylelint/changelog-to-github-release-action@8526eab6046b8f5b2f883844d953b5eb6f80e674 # 0.5.1
   with:
+    tag: ${{ github.event.inputs.new-tag }}
     draft: true
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'GitHub Action to convert CHANGELOG to GitHub Release'
 author: 'Stylelint'
 inputs:
   tag:
-    description: 'Tag name.'
+    description: 'Tag name. If it does not exist, it will be automatically created.'
     required: false
     default: '${{ github.ref_name }}'
   name:

--- a/dist/index.js
+++ b/dist/index.js
@@ -50393,6 +50393,7 @@ const remark = unified().use(remarkParse).use(remarkStringify).freeze()
  */
 function extractChangeItems({ version }) {
 	return (tree) => {
+		let foundVersion = false;
 		/** @type {import('mdast').List | undefined} */
 		let list;
 
@@ -50404,6 +50405,7 @@ function extractChangeItems({ version }) {
 				parent &&
 				index !== undefined
 			) {
+				foundVersion = true;
 				const nextSiblings = parent.children.slice(index + 1);
 				for (const sibling of nextSiblings) {
 					if (sibling.type === 'list') {
@@ -50415,8 +50417,12 @@ function extractChangeItems({ version }) {
 			return CONTINUE;
 		});
 
+		if (!foundVersion) {
+			throw new Error(`Not found the version ${version} in the changelog`);
+		}
+
 		if (!list) {
-			throw new Error(`Not found version: ${version}`);
+			throw new Error(`Not found list under the ${version} heading in the changelog`);
 		}
 
 		// Rewrite a link or reference to a PR notation (#123) or a user mention (@username).

--- a/src/__tests__/changelogToGithubRelease.test.js
+++ b/src/__tests__/changelogToGithubRelease.test.js
@@ -53,14 +53,32 @@ test('rewrite change items matching specified version', async () => {
 	assert.equal(result, '* aaa #123 (@user).\n* bbb.\n');
 });
 
-test('raise an error when a specified version is not found', async () => {
+test('raise an error when a specified version is not found in the changelog', async () => {
 	assert.rejects(
 		async () => {
 			await changelogToGithubRelease(changelog, '2.0.0');
 		},
 		{
 			name: 'Error',
-			message: 'Not found version: 2.0.0',
+			message: 'Not found the version 2.0.0 in the changelog',
+		},
+	);
+});
+
+test('raise an error when a list under the specified version is not found in the changelog', async () => {
+	const invalidChangelog = `
+# Changelog
+## 1.0.0
+No list.
+`;
+
+	assert.rejects(
+		async () => {
+			await changelogToGithubRelease(invalidChangelog, '1.0.0');
+		},
+		{
+			name: 'Error',
+			message: 'Not found list under the 1.0.0 heading in the changelog',
 		},
 	);
 });

--- a/src/changelogToGithubRelease.js
+++ b/src/changelogToGithubRelease.js
@@ -7,6 +7,7 @@ import { visit, CONTINUE, EXIT } from 'unist-util-visit';
  */
 function extractChangeItems({ version }) {
 	return (tree) => {
+		let foundVersion = false;
 		/** @type {import('mdast').List | undefined} */
 		let list;
 
@@ -18,6 +19,7 @@ function extractChangeItems({ version }) {
 				parent &&
 				index !== undefined
 			) {
+				foundVersion = true;
 				const nextSiblings = parent.children.slice(index + 1);
 				for (const sibling of nextSiblings) {
 					if (sibling.type === 'list') {
@@ -29,8 +31,12 @@ function extractChangeItems({ version }) {
 			return CONTINUE;
 		});
 
+		if (!foundVersion) {
+			throw new Error(`Not found the version ${version} in the changelog`);
+		}
+
 		if (!list) {
-			throw new Error(`Not found version: ${version}`);
+			throw new Error(`Not found list under the ${version} heading in the changelog`);
 		}
 
 		// Rewrite a link or reference to a PR notation (#123) or a user mention (@username).


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

For example, error messages such as "*Not found version: 1.0.0*" are not so helpful.

In addition, this improves the README and the `tag` input description as the documentation.
