### PR TITLE
Fix release workflows by specifying Node.js version

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,10 +10,27 @@ on:
         options: [patch, minor, major]
 
 jobs:
+  get-node-version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.node-version.outputs.value }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Get Node.js version from package.json
+        id: node-version
+        shell: bash
+        run: echo "value=$(jq -r '.engines.node' package.json)" >> "${GITHUB_OUTPUT}"
+
   release-pr:
-    uses: stylelint/.github/.github/workflows/call-release-pr.yml@94de5d411af0abade18762a5ae243601d4bbfa98 # 0.1.1
+    needs: get-node-version
+    uses: stylelint/.github/.github/workflows/call-release-pr.yml@45666ef076bb454406bde671ade1f0f852eb70cc # 0.2.0
     with:
       new-version: ${{ github.event.inputs.new-version }}
+      node-version: ${{ needs.get-node-version.outputs.version }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,27 @@ on:
     types: [closed]
 
 jobs:
+  get-node-version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.node-version.outputs.value }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Get Node.js version from package.json
+        id: node-version
+        shell: bash
+        run: echo "value=$(jq -r '.engines.node' package.json)" >> "${GITHUB_OUTPUT}"
+
   release:
-    uses: stylelint/.github/.github/workflows/call-release.yml@94de5d411af0abade18762a5ae243601d4bbfa98 # 0.1.1
+    needs: get-node-version
+    uses: stylelint/.github/.github/workflows/call-release.yml@45666ef076bb454406bde671ade1f0f852eb70cc # 0.2.0
     with:
       publish: false
+      node-version: ${{ needs.get-node-version.outputs.version }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,12 @@ on:
     branches: ['main']
   pull_request:
 
-permissions: read-all
-
 jobs:
   get-node-version:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.node-version.outputs.value }}
     steps:
@@ -19,11 +19,11 @@ jobs:
       - name: Get Node.js version from package.json
         id: node-version
         shell: bash
-        run: echo "value=$(npm pkg get 'engines.node' | jq -r)" >> "${GITHUB_OUTPUT}"
+        run: echo "value=$(jq -r '.engines.node' package.json)" >> "${GITHUB_OUTPUT}"
 
   lint:
     needs: get-node-version
-    uses: stylelint/.github/.github/workflows/call-lint.yml@94de5d411af0abade18762a5ae243601d4bbfa98 # 0.1.1
+    uses: stylelint/.github/.github/workflows/call-lint.yml@45666ef076bb454406bde671ade1f0f852eb70cc # 0.2.0
     with:
       node-version: ${{ needs.get-node-version.outputs.version }}
     permissions:
@@ -31,7 +31,7 @@ jobs:
 
   test:
     needs: get-node-version
-    uses: stylelint/.github/.github/workflows/call-test.yml@94de5d411af0abade18762a5ae243601d4bbfa98 # 0.1.1
+    uses: stylelint/.github/.github/workflows/call-test.yml@45666ef076bb454406bde671ade1f0f852eb70cc # 0.2.0
     with:
       node-version: '["${{ needs.get-node-version.outputs.version}}"]'
     permissions:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This resolves the following error:

```
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: changelog-to-github-release-action@0.5.1
npm error notsup Not compatible with your version of node/npm: changelog-to-github-release-action@0.5.1
npm error notsup Required: {"node":"24"}
npm error notsup Actual:   {"npm":"11.6.1","node":"v22.19.0"}
```

Ref https://github.com/stylelint/changelog-to-github-release-action/actions/runs/18153408568/job/51668225341#step:5:5
