### PR TITLE
Remove `husky`

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+lint-staged

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-lint-staged
+npx --no lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@tsconfig/strictest": "^2.0.8",
         "@types/mdast": "^4.0.4",
         "@vercel/ncc": "^0.38.4",
-        "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.8.1",
@@ -1614,22 +1613,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
-    },
-    "node_modules/husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
     },
     "node_modules/ignore": {
       "version": "5.2.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:formatting": "prettier . --check --cache",
     "lint:md": "remark . --quiet --frail",
     "lint:types": "tsc",
-    "prepare": "husky",
+    "prepare": "git config set --local core.hooksPath .githooks || true",
     "pretest": "npm run lint",
     "test": "node --test && npm run build && npm run build-check",
     "watch": "node --test --watch"
@@ -42,7 +42,6 @@
     "@tsconfig/strictest": "^2.0.8",
     "@types/mdast": "^4.0.4",
     "@vercel/ncc": "^0.38.4",
-    "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.8.1",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Same as https://github.com/stylelint/stylelint/pull/8984

> Is there anything in the PR that needs further explanation?

This replaces `husky` with the built-in `core.gitHooks`.

Note: This change is generated by the following shell commands:

```shell
# Update package.json
npm pkg set scripts.prepare="git config set --local core.hooksPath .githooks || true"
npm rm husky

# Update pre-commit hook
rm -rf .githooks
mv -f .husky .githooks
sed -i '' '1s|^|#!/usr/bin/env sh\n\n|' .githooks/pre-commit
chmod +x .githooks/pre-commit
```
